### PR TITLE
Update GlobusComputeLauncher to reuse a single GCExecutor

### DIFF
--- a/flox/backends/launcher/impl_globus.py
+++ b/flox/backends/launcher/impl_globus.py
@@ -3,6 +3,7 @@ from typing import Any, Callable
 
 from flox.flock import FlockNode
 from flox.backends.launcher.impl_base import Launcher
+import globus_compute_sdk
 
 
 class GlobusComputeLauncher(Launcher):
@@ -10,17 +11,19 @@ class GlobusComputeLauncher(Launcher):
     Class that executes tasks on Globus Compute.
     """
 
+    _globus_compute_executor: globus_compute_sdk.Executor | None = None
+
     def __init__(self):
         super().__init__()
+        if self._globus_compute_executor is None:
+            self._globus_compute_executor = globus_compute_sdk.Executor()
 
     def submit(
         self, fn: Callable[[FlockNode, ...], Any], node: FlockNode, /, *args, **kwargs
     ) -> Future:
-        import globus_compute_sdk as globus_compute
-
         endpoint_id = node.globus_compute_endpoint
-        with globus_compute.Executor(endpoint_id=endpoint_id) as gce:
-            future = gce.submit(fn, node, *args, **kwargs)
+        self._globus_compute_executor.endpoint_id = endpoint_id
+        future = self._globus_compute_executor.submit(fn, node, *args, **kwargs)
         return future
 
     def collect(self):


### PR DESCRIPTION
This PR updates the `GlobusComputeLauncher` to reuse a single Globus Compute Executor.

The current implementation creates a new executor instance for every `Launcher.submit(...)` call which is expensive.
The changes here are untested as of now, so I'm marking the PR as a draft.